### PR TITLE
Actually use configured smtp_url setting

### DIFF
--- a/crawler.py
+++ b/crawler.py
@@ -89,7 +89,7 @@ def send_email(msg_content):
 
     try:
         # Try to login smtp server
-        s = smtplib.SMTP("smtp.gmail.com:587")
+        s = smtplib.SMTP(emailinfo['smtp_url'])
         s.ehlo()
         s.starttls()
         s.login(emailinfo['sender'], emailinfo['sender-password'])


### PR DESCRIPTION
Instead of using the hardcoded Gmail SMTP server, this will use the already existing 'smtp_url' setting from config.json.